### PR TITLE
make ^W delete backward when there is no mark

### DIFF
--- a/expeditor-doc/expeditor.scrbl
+++ b/expeditor-doc/expeditor.scrbl
@@ -211,8 +211,9 @@ holding the Shift key).
        cursor, but invisible, that is used by various editing
        operations.}
 
-  @key["^W" ee-delete-between-point-and-mark]{Deletes content between
-       the cursor and the @tech{mark}.}
+  @key["^W" ee-delete-between-point-and-mark-or-backward]{Deletes content between
+       the cursor and the @tech{mark}. When no mark is set, deletes
+       one expression before the cursor.}
 
   @key["^Y" ee-yank-kill-buffer]{Inserts content previously deleted,
        where multiple consecutive deletions accumulate to one set of

--- a/expeditor-lib/main.rkt
+++ b/expeditor-lib/main.rkt
@@ -712,6 +712,11 @@
           (beep "mark not set")))
     entry))
 
+(define (ee-delete-between-point-and-mark-or-backward ee entry c)
+  (if (entry-mark entry)
+      (ee-delete-between-point-and-mark ee entry c)
+      (ee-backward-delete-exp ee entry c)))
+
 (define ee-set-mark
   (lambda (ee entry c)
     (entry-mark-set! entry (entry-point entry))
@@ -1146,7 +1151,7 @@
   (ebk "^U"       ee-delete-line)                     ; ^U
   (ebk "^K"       ee-delete-to-eol)                   ; ^K
   (ebk "\\ek"     ee-delete-to-eol)                   ; Esc-k
-  (ebk "^W"       ee-delete-between-point-and-mark)   ; ^W
+  (ebk "^W"       ee-delete-between-point-and-mark-or-backward)   ; ^W
   (ebk "^G"       ee-delete-entry)                    ; ^G
   (ebk "^C"       ee-reset-entry)                     ; ^C
   (ebk "\\e^K"    ee-delete-exp)                      ; Esc-^K


### PR DESCRIPTION
Under readline, ^W defaults to `unix-word-rubout`, which kills the word behind the point.  This change makes expeditor roughly behave the same when there is no mark. 