### PR TITLE
bind Meta-d to ee-delete-word

### DIFF
--- a/expeditor-doc/expeditor.scrbl
+++ b/expeditor-doc/expeditor.scrbl
@@ -201,6 +201,9 @@ holding the Shift key).
        region is empty, in which case a break signal is sent to the current
        thread.}
 
+  @key[("Esc-d") ee-delete-word]{Deletes one whitespace-delimited word
+       after the cursor.}
+
   @key[("Esc-Delete" "Esc-^K") ee-delete-exp]{Deletes one expression
        after the cursor, where the definition of ``expression'' is
        language-specific.}

--- a/expeditor-lib/main.rkt
+++ b/expeditor-lib/main.rkt
@@ -800,6 +800,18 @@
           (beep "start of expression not found"))))
     entry))
 
+(define (ee-delete-word ee entry c)
+  (define pos
+    (find-next-word
+     ee entry
+     (entry-row entry)
+     (entry-col entry)))
+  (delete-forward
+   ee entry
+   (pos-row pos)
+   (pos-col pos))
+  entry)
+
 (define ee-redisplay
   (lambda (ee entry c)
     (if (eq? (eestate-last-op ee) ee-redisplay)
@@ -1164,6 +1176,7 @@
   (ebk "^W"       ee-delete-between-point-and-mark-or-backward)   ; ^W
   (ebk "^G"       ee-delete-entry)                    ; ^G
   (ebk "^C"       ee-reset-entry/break)               ; ^C
+  (ebk "\\ed"     ee-delete-word)                     ; Esc-d
   (ebk "\\e^K"    ee-delete-exp)                      ; Esc-^K
   (ebk "\\e\\e[3~" ee-delete-exp)                     ; Esc-Delete
   (ebk "\\e\177"  ee-backward-delete-exp)             ; Esc-Backspace


### PR DESCRIPTION
This change makes the binding behave like the default M-d binding for readline, which kills the word following the point.

I wasn't sure whether it would be better to bind it to `ee-delete-exp` or introduce the by-word version. This behavior seems more in line with `Meta-f` and `Meta-b`, and `Meta-^k` is already bound to the structural version, but I have no strong feelings either way.