### PR TITLE
make expeditor more friendly for integration

### DIFF
--- a/expeditor-doc/expeditor.scrbl
+++ b/expeditor-doc/expeditor.scrbl
@@ -600,7 +600,7 @@ a space is added between @racket[prompt-str] and input, unless
 
 @history[#:changed "1.1" @elem{Added the @racket[#:prompt] argument.}]}
 
-@defproc[(call-with-expeditor [proc ((-> any/c) -> any)]
+@defproc[(call-with-expeditor [proc ((->* () (#:prompt string?) any/c) -> any)]
                               [#:prompt prompt-str string? ">"])
          any]{
 
@@ -608,7 +608,8 @@ Combines @racket[expeditor-open], a call to @racket[proc], and
 @racket[expeditor-close], where the reading procedure passed to
 @racket[proc] can be called any number of times to read input.
 The @racket[prompt-str] argument is used in the same way as for
-@racket[expeditor-read].
+@racket[expeditor-read], the reading procedure can also receive an 
+optional string to update the @racket[prompt-str].
 
 Expeditor history is initialized from
 @racket[current-expeditor-history] on open, and the value of

--- a/expeditor-lib/main.rkt
+++ b/expeditor-lib/main.rkt
@@ -1449,7 +1449,7 @@
   (lambda (proc #:prompt [prompt ">"])
     (unless (string? prompt) (raise-argument-error 'call-with-expeditor "string?" prompt))
     (let ([ee #f])
-      (define (expeditor-prompt-and-read n)
+      (define (expeditor-prompt-and-read n read-prompt)
         (if (cond
               [(eestate? ee) #t]
               [(eq? ee 'failed) #f]
@@ -1458,12 +1458,12 @@
                     (set! ee new-ee)
                     #t)]
               [else (set! ee 'failed) #f])
-            (ee-prompt-and-read ee n prompt)
+            (ee-prompt-and-read ee n read-prompt)
             (default-prompt-and-read n)))
       (let ([val* (call-with-values
                    (lambda ()
-                     (proc (lambda ()
-                             (expeditor-prompt-and-read 1))))
+                     (proc (lambda (#:prompt [read-prompt prompt])
+                             (expeditor-prompt-and-read 1 read-prompt))))
                    list)])
         (when (eestate? ee)
           (current-expeditor-history (expeditor-close ee)))


### PR DESCRIPTION
1. allows updating prompt through the reader proc in `call-with-expeditor`
2. supports the prompt with ANSI escape sequences
3. supports the completer whose returning is in string